### PR TITLE
fix: handle quoted arguments in command execution

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -3,6 +3,7 @@ import subprocess
 from flask_cors import CORS
 import os
 import csv
+import shlex
 from werkzeug.utils import secure_filename
 
 app = Flask(__name__)
@@ -41,8 +42,12 @@ def run_command():
         return jsonify({"status": "active", "message": "Servidor online."})
 
     # --- PARSEO SEGURO DE COMANDOS ---
-    # Dividir el comando y sus argumentos.
-    command_parts = command.strip().split()
+    # Dividir el comando y sus argumentos utilizando shlex para respetar comillas
+    try:
+        command_parts = shlex.split(command)
+    except ValueError as e:
+        return jsonify({"error": f"Invalid command: {str(e)}"}), 400
+
     base_command = command_parts[0]
 
     # Validar que el comando base esté en la lista blanca.


### PR DESCRIPTION
## Summary
- use `shlex.split` to parse commands with quoted arguments
- return 400 for invalid command syntax

## Testing
- `python -m py_compile backend/server.py`
- `python - <<'PY'
from backend.server import app
import base64, os
client = app.test_client()
creds = base64.b64encode(b'admin:123456').decode()
resp = client.post('/run', json={'command': 'mkdir "new folder"'}, headers={'Authorization': 'Basic '+creds})
print('mkdir status', resp.status_code)
print('exists', os.path.isdir('new folder'))
os.rmdir('new folder')
PY`


------
https://chatgpt.com/codex/tasks/task_e_6893bb6a9cb4832a974f92f9f44d98a9