### PR TITLE
Control debug mode through FLASK_ENV and document WSGI usage

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,17 @@
+# Backend
+
+## Desarrollo
+
+Ejecutar el servidor con el modo de depuración activado:
+
+```bash
+FLASK_ENV=development python server.py
+```
+
+## Producción
+
+Usar un servidor WSGI como Gunicorn:
+
+```bash
+gunicorn -w 4 server:app
+```

--- a/backend/server.py
+++ b/backend/server.py
@@ -111,7 +111,9 @@ def read_csv_file():
         return jsonify({"error": f"Error reading CSV file: {str(e)}"}), 500
 
 if __name__ == "__main__":
-    # Esta línea te confirmará que el servidor se está iniciando.
+    # Inicia el servidor de desarrollo solo si se ejecuta directamente
+    # FLASK_ENV=development habilita el modo debug.
+    debug_mode = os.environ.get("FLASK_ENV") == "development"
     print("🚀 Servidor Flask iniciándose en http://0.0.0.0:80 (Requiere sudo para ejecutar)")
-    # Esta línea inicia el servidor y lo mantiene escuchando peticiones.
-    app.run(host="0.0.0.0", port=80, debug=True)
+    # No usar en producción; en su lugar usar un servidor WSGI como Gunicorn.
+    app.run(host="0.0.0.0", port=80, debug=debug_mode)


### PR DESCRIPTION
## Summary
- Control Flask debug setting via `FLASK_ENV` and warn against using built‑in server in production.
- Add backend README with instructions for development and WSGI/Gunicorn deployment.

## Testing
- `python -m py_compile backend/server.py`


------
https://chatgpt.com/codex/tasks/task_e_6893c2cb39f4832a8d10e1a9abb3e3a5