### PR TITLE
Add backend endpoint for contact emails

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -50,7 +50,7 @@ function initLeafletMap() {
 }
 
 /**
- * Inicializa la lógica del formulario de contacto de EmailJS.
+ * Inicializa la lógica del formulario de contacto enviando los datos al backend.
  */
 function initContactForm() {
     const contactForm = document.getElementById('form-contact');
@@ -94,8 +94,20 @@ function initContactForm() {
 
         submitAttempts++;
 
-        emailjs.sendForm('NOKCOMPANY', 'template_jbnt66h', this, '4yv6lNv3D75wM1BVV')
-            .then(function(response) {
+        fetch('/send-email', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ nombre, correo, mensaje })
+        })
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('Network response was not ok');
+                }
+                return response.json();
+            })
+            .then(() => {
                 document.querySelector('.form-contact-status').innerHTML =
                     "<div class='alert alert-success mt-3'>¡Mensaje enviado con éxito!</div>";
                 e.target.reset();
@@ -104,7 +116,7 @@ function initContactForm() {
                     submitAttempts = Math.max(0, submitAttempts - 1);
                 }, COOLDOWN_TIME);
             })
-            .catch(function(error) {
+            .catch(error => {
                 console.error('Error:', error);
                 document.querySelector('.form-contact-status').innerHTML =
                     "<div class='alert alert-danger mt-3'>Error al enviar el mensaje. Inténtalo de nuevo.</div>";

--- a/backend/server.py
+++ b/backend/server.py
@@ -5,9 +5,13 @@ import os
 import csv
 import shlex
 from werkzeug.utils import secure_filename
+import requests
 
 app = Flask(__name__)
 CORS(app)
+
+# Clave del servicio de correo almacenada como variable de entorno
+EMAILJS_PUBLIC_KEY = os.environ.get("EMAILJS_PUBLIC_KEY")
 
 # Lista blanca de comandos permitidos. Usar un set es más eficiente para búsquedas.
 ALLOWED_COMMANDS = {'ls', 'mkdir', 'date', 'pwd', 'whoami', 'status', 'cd'} 
@@ -109,6 +113,38 @@ def read_csv_file():
         return jsonify(rows)
     except Exception as e:
         return jsonify({"error": f"Error reading CSV file: {str(e)}"}), 500
+
+
+@app.route("/send-email", methods=["POST"])
+def send_email():
+    data = request.get_json()
+    nombre = data.get("nombre")
+    correo = data.get("correo")
+    mensaje = data.get("mensaje")
+
+    if not EMAILJS_PUBLIC_KEY:
+        return jsonify({"error": "Email service key not configured"}), 500
+
+    payload = {
+        "service_id": "NOKCOMPANY",
+        "template_id": "template_jbnt66h",
+        "user_id": EMAILJS_PUBLIC_KEY,
+        "template_params": {
+            "nombre": nombre,
+            "correo": correo,
+            "mensaje": mensaje,
+        },
+    }
+
+    try:
+        response = requests.post(
+            "https://api.emailjs.com/api/v1.0/email/send", json=payload
+        )
+        if response.status_code == 200:
+            return jsonify({"success": True})
+        return jsonify({"error": "Failed to send email"}), 500
+    except requests.RequestException as e:
+        return jsonify({"error": str(e)}), 500
 
 if __name__ == "__main__":
     # Esta línea te confirmará que el servidor se está iniciando.


### PR DESCRIPTION
## Summary
- add `/send-email` endpoint that sends contact form emails using EmailJS and an API key from `EMAILJS_PUBLIC_KEY`
- update client form handler to `fetch` the backend endpoint instead of `emailjs.sendForm`

## Testing
- `python -m py_compile backend/server.py`
- `python backend/server.py` (fails without environment key but server starts)
- `node --check assets/js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_6893c2cce544832aa81daa6203973a40