### PR TITLE
feat: enable extensionless routing

### DIFF
--- a/index/index.html
+++ b/index/index.html
@@ -5,17 +5,17 @@
 	<meta name="author" content="NokServices">
 
     <!-- Favicon -->
-    <link rel="icon" type="image/png" href="assets/img/logo.png">
-    <link rel="shortcut icon" type="image/png" href="assets/img/logo.png">
-    <link rel="apple-touch-icon" href="assets/img/logo.png">
+    <link rel="icon" type="image/png" href="../assets/img/logo.png">
+    <link rel="shortcut icon" type="image/png" href="../assets/img/logo.png">
+    <link rel="apple-touch-icon" href="../assets/img/logo.png">
 
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Poppins:400,500,600">
-    <link rel="stylesheet" href="assets/bootstrap/css/bootstrap.min.css" type="text/css">
-    <link rel="stylesheet" href="assets/font-awesome/css/fontawesome-all.min.css">
-    <link rel="stylesheet" href="assets/css/magnific-popup.css">
-    <link rel="stylesheet" href="assets/css/style.css">
+    <link rel="stylesheet" href="../assets/bootstrap/css/bootstrap.min.css" type="text/css">
+    <link rel="stylesheet" href="../assets/font-awesome/css/fontawesome-all.min.css">
+    <link rel="stylesheet" href="../assets/css/magnific-popup.css">
+    <link rel="stylesheet" href="../assets/css/style.css">
     <!-- Custom styles moved to Assets/css/custom-styles.css -->
-    <link rel="stylesheet" href="assets/css/custom-styles.css">
+    <link rel="stylesheet" href="../assets/css/custom-styles.css">
 
 	<title>Nok Services</title>
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
@@ -51,7 +51,7 @@
                     <a class="navbar-brand" href="/">
                         <div class="brand-container">
                             <img src="https://flagcdn.com/w20/cl.png" alt="Bandera de Chile">
-                            <img src="assets/img/logo.png" alt="">
+                            <img src="../assets/img/logo.png" alt="">
                         </div>
                     </a>
                     <div class="navbar-nav ml-auto custom-nav">
@@ -157,8 +157,8 @@
                              <!-- Custom LinkedIn Module Modifications -->
                              <a href="https://www.linkedin.com/company/nokspa" target="_blank" style="text-decoration: none;">
                                 <div class="linkedin-widget" style="margin-top: 15px; display: flex; align-items: center; justify-content: flex-start; gap: 10px; background: rgba(255,255,255,0.1); border-radius: 12px; padding: 20px; backdrop-filter: blur(5px); border: 1px solid rgba(255,255,255,0.1); box-shadow: 0 4px 12px rgba(0,0,0,0.1); transition: all 0.3s ease;">
-                                   <img src="assets/img/logolink.png" alt="LinkedIn Logo" style="max-height: 95px; width: auto;">
-                                   <img src="assets/img/logomosaico.png" alt="Nok Mosaic Logo" style="max-height: 60px; width: auto;">
+                                   <img src="../assets/img/logolink.png" alt="LinkedIn Logo" style="max-height: 95px; width: auto;">
+                                   <img src="../assets/img/logomosaico.png" alt="Nok Mosaic Logo" style="max-height: 60px; width: auto;">
                                    <span style="font-size: 20px; font-weight: bold; color: white; margin-left: 20px;">Follow us on Linkedin Profile</span>
                                 </div>
                               </a>
@@ -202,20 +202,20 @@
 
     <!--BACKGROUND **********************************************************************************************-->
     <div class="ts-background ts-shapes-canvas position-fixed ts-separate-bg-element" data-bg-color="#26005F">
-        <div class="ts-background-image ts-animate ts-scale" data-bg-image="assets/img/bg/14.png"></div>
-        <div class="ts-background-image ts-animate ts-bounce" data-bg-image="assets/img/bg/13.png"></div>
-        <div class="ts-background-image ts-animate ts-scale" data-bg-image="assets/img/bg/12.png" data-bg-opacity=".3"></div>
-        <div class="ts-background-image ts-animate ts-scale" data-bg-image="assets/img/bg/11.png"></div>
-        <div class="ts-background-image ts-animate ts-bounce" data-bg-image="assets/img/bg/10.png"></div>
-        <div class="ts-background-image ts-animate ts-bounce" data-bg-image="assets/img/bg/9.png" data-bg-opacity=".8"></div>
-        <div class="ts-background-image ts-animate ts-bounce" data-bg-image="assets/img/bg/8.png" data-bg-opacity=".8"></div>
-        <div class="ts-background-image ts-animate ts-bounce" data-bg-image="assets/img/bg/7.png"></div>
-        <div class="ts-background-image ts-animate ts-bounce" data-bg-image="assets/img/bg/6.png" data-bg-opacity=".8"></div>
-        <div class="ts-background-image ts-animate" data-bg-image="assets/img/bg/5.png" data-bg-opacity=".8"></div>
-        <div class="ts-background-image ts-animate ts-bounce" data-bg-image="assets/img/bg/4.png"></div>
-        <div class="ts-background-image ts-animate ts-bounce" data-bg-image="assets/img/bg/3.png" data-bg-opacity=".8"></div>
-        <div class="ts-background-image ts-animate ts-bounce" data-bg-image="assets/img/bg/2.png"></div>
-        <div class="ts-background-image ts-animate ts-bounce" data-bg-image="assets/img/bg/1.png" data-bg-opacity=".8"></div>
+        <div class="ts-background-image ts-animate ts-scale" data-bg-image="../assets/img/bg/14.png"></div>
+        <div class="ts-background-image ts-animate ts-bounce" data-bg-image="../assets/img/bg/13.png"></div>
+        <div class="ts-background-image ts-animate ts-scale" data-bg-image="../assets/img/bg/12.png" data-bg-opacity=".3"></div>
+        <div class="ts-background-image ts-animate ts-scale" data-bg-image="../assets/img/bg/11.png"></div>
+        <div class="ts-background-image ts-animate ts-bounce" data-bg-image="../assets/img/bg/10.png"></div>
+        <div class="ts-background-image ts-animate ts-bounce" data-bg-image="../assets/img/bg/9.png" data-bg-opacity=".8"></div>
+        <div class="ts-background-image ts-animate ts-bounce" data-bg-image="../assets/img/bg/8.png" data-bg-opacity=".8"></div>
+        <div class="ts-background-image ts-animate ts-bounce" data-bg-image="../assets/img/bg/7.png"></div>
+        <div class="ts-background-image ts-animate ts-bounce" data-bg-image="../assets/img/bg/6.png" data-bg-opacity=".8"></div>
+        <div class="ts-background-image ts-animate" data-bg-image="../assets/img/bg/5.png" data-bg-opacity=".8"></div>
+        <div class="ts-background-image ts-animate ts-bounce" data-bg-image="../assets/img/bg/4.png"></div>
+        <div class="ts-background-image ts-animate ts-bounce" data-bg-image="../assets/img/bg/3.png" data-bg-opacity=".8"></div>
+        <div class="ts-background-image ts-animate ts-bounce" data-bg-image="../assets/img/bg/2.png"></div>
+        <div class="ts-background-image ts-animate ts-bounce" data-bg-image="../assets/img/bg/1.png" data-bg-opacity=".8"></div>
     </div>
     <!--end ts-background-->
 
@@ -255,16 +255,16 @@
     <!--************ JS SCRIPTS *************************************************************************************-->
     <!--*************************************************************************************************************-->
 
-	<script src="assets/js/jquery-3.3.1.min.js"></script>
-	<script src="assets/js/popper.min.js"></script>
-	<script src="assets/bootstrap/js/bootstrap.min.js"></script>
-    <script src="assets/js/imagesloaded.pkgd.min.js"></script>
-    <script src="assets/js/jquery.magnific-popup.min.js"></script>
-	<script src="assets/js/jquery.countdown.min.js"></script>
-	<script src="assets/js/jquery.validate.min.js"></script>
-	<script src="assets/js/jquery-validate.bootstrap-tooltip.min.js"></script>
+	<script src="../assets/js/jquery-3.3.1.min.js"></script>
+	<script src="../assets/js/popper.min.js"></script>
+	<script src="../assets/bootstrap/js/bootstrap.min.js"></script>
+    <script src="../assets/js/imagesloaded.pkgd.min.js"></script>
+    <script src="../assets/js/jquery.magnific-popup.min.js"></script>
+	<script src="../assets/js/jquery.countdown.min.js"></script>
+	<script src="../assets/js/jquery.validate.min.js"></script>
+	<script src="../assets/js/jquery-validate.bootstrap-tooltip.min.js"></script>
 
-    <script src="assets/js/custom.js"></script> <!-- Tu script de plantilla -->
-    <script src="assets/js/main.js" defer></script> <!-- Nuestro nuevo script centralizado -->
+    <script src="../assets/js/custom.js"></script> <!-- Tu script de plantilla -->
+    <script src="../assets/js/main.js" defer></script> <!-- Nuestro nuevo script centralizado -->
 </body>
 </html>

--- a/producto/index.html
+++ b/producto/index.html
@@ -6,16 +6,16 @@
     <meta name="author" content="NokServices">
 
     <!-- Favicon -->
-    <link rel="icon" type="image/png" href="assets/img/logo.png">
-    <link rel="shortcut icon" type="image/png" href="assets/img/logo.png">
-    <link rel="apple-touch-icon" href="assets/img/logo.png">
+    <link rel="icon" type="image/png" href="../assets/img/logo.png">
+    <link rel="shortcut icon" type="image/png" href="../assets/img/logo.png">
+    <link rel="apple-touch-icon" href="../assets/img/logo.png">
 
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Poppins:400,500,600">
-    <link rel="stylesheet" href="assets/bootstrap/css/bootstrap.min.css" type="text/css">
-    <link rel="stylesheet" href="assets/font-awesome/css/fontawesome-all.min.css">
-    <link rel="stylesheet" href="assets/css/magnific-popup.css">
-    <link rel="stylesheet" href="assets/css/style.css">
-    <link rel="stylesheet" href="assets/css/custom-styles.css">
+    <link rel="stylesheet" href="../assets/bootstrap/css/bootstrap.min.css" type="text/css">
+    <link rel="stylesheet" href="../assets/font-awesome/css/fontawesome-all.min.css">
+    <link rel="stylesheet" href="../assets/css/magnific-popup.css">
+    <link rel="stylesheet" href="../assets/css/style.css">
+    <link rel="stylesheet" href="../assets/css/custom-styles.css">
     <title>Producto - Nok Services</title>
 
     <!-- Meta tags de seguridad -->
@@ -30,17 +30,17 @@
             <!-- Navigation -->
             <header id="header">
                 <nav class="navbar navbar-dark ts-separate-bg-element">
-                    <a class="navbar-brand" href="index.html">
+                    <a class="navbar-brand" href="/">
                         <div class="brand-container">
                             <img src="https://flagcdn.com/w20/cl.png" alt="Bandera de Chile">
-                            <img src="assets/img/logo.png" alt="">
+                            <img src="../assets/img/logo.png" alt="">
                         </div>
                     </a>
                     <div class="navbar-nav ml-auto custom-nav">
                         <div class="nav-container">
-                            <a href="index.html" class="nav-link">Start</a>
-                            <a href="servicios.html" class="nav-link">Services</a>
-                            <a href="producto.html" class="nav-link active">Product</a>
+                            <a href="/" class="nav-link">Start</a>
+                            <a href="/servicios/" class="nav-link">Services</a>
+                            <a href="/producto/" class="nav-link active">Product</a>
                             <a href="test.html" class="nav-link">TEST</a>
                         </div>
                     </div>
@@ -80,7 +80,7 @@
                         <div class="col-lg-5">
                             <div class="product-purchase-card">
                                 <div class="product-image-container">
-                                    <img src="assets/img/JULY.png" alt="Logo del Producto NOK LEADS" class="product-logo-img img-fluid" style="max-width: 75%; height: auto;">
+                                    <img src="../assets/img/JULY.png" alt="Logo del Producto NOK LEADS" class="product-logo-img img-fluid" style="max-width: 75%; height: auto;">
                                 </div>
                                 <h3>Lifetime License</h3>
                                 <p>Monthly subscription for access to all features and regular updates.</p>
@@ -115,18 +115,18 @@
 
     <!-- Background -->
     <div class="ts-background ts-shapes-canvas position-fixed ts-separate-bg-element" data-bg-color="#26005F">
-        <div class="ts-background-image ts-animate ts-scale" data-bg-image="assets/img/bg/14.png"></div>
-        <div class="ts-background-image ts-animate ts-bounce" data-bg-image="assets/img/bg/13.png"></div>
-        <div class="ts-background-image ts-animate ts-scale" data-bg-image="assets/img/bg/12.png" data-bg-opacity=".3"></div>
+        <div class="ts-background-image ts-animate ts-scale" data-bg-image="../assets/img/bg/14.png"></div>
+        <div class="ts-background-image ts-animate ts-bounce" data-bg-image="../assets/img/bg/13.png"></div>
+        <div class="ts-background-image ts-animate ts-scale" data-bg-image="../assets/img/bg/12.png" data-bg-opacity=".3"></div>
     </div>
 
     <!-- Scripts remain unchanged -->
-    <script src="assets/js/jquery-3.3.1.min.js"></script>
-    <script src="assets/js/popper.min.js"></script>
-    <script src="assets/bootstrap/js/bootstrap.min.js"></script>
+    <script src="../assets/js/jquery-3.3.1.min.js"></script>
+    <script src="../assets/js/popper.min.js"></script>
+    <script src="../assets/bootstrap/js/bootstrap.min.js"></script>
     <script src="https://unpkg.com/swup@4" defer></script>
-    <script src="assets/js/imagesloaded.pkgd.min.js"></script>
-    <script src="assets/js/custom.js"></script>
-    <script src="assets/js/main.js" defer></script>
+    <script src="../assets/js/imagesloaded.pkgd.min.js"></script>
+    <script src="../assets/js/custom.js"></script>
+    <script src="../assets/js/main.js" defer></script>
 </body>
 </html>

--- a/servicios/index.html
+++ b/servicios/index.html
@@ -6,16 +6,16 @@
     <meta name="author" content="NokServices">
 
     <!-- Favicon -->
-    <link rel="icon" type="image/png" href="assets/img/logo.png">
-    <link rel="shortcut icon" type="image/png" href="assets/img/logo.png">
-    <link rel="apple-touch-icon" href="assets/img/logo.png">
+    <link rel="icon" type="image/png" href="../assets/img/logo.png">
+    <link rel="shortcut icon" type="image/png" href="../assets/img/logo.png">
+    <link rel="apple-touch-icon" href="../assets/img/logo.png">
 
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Poppins:400,500,600">
-    <link rel="stylesheet" href="assets/bootstrap/css/bootstrap.min.css" type="text/css">
-    <link rel="stylesheet" href="assets/font-awesome/css/fontawesome-all.min.css">
-    <link rel="stylesheet" href="assets/css/magnific-popup.css">
-    <link rel="stylesheet" href="assets/css/style.css">
-    <link rel="stylesheet" href="assets/css/custom-styles.css">
+    <link rel="stylesheet" href="../assets/bootstrap/css/bootstrap.min.css" type="text/css">
+    <link rel="stylesheet" href="../assets/font-awesome/css/fontawesome-all.min.css">
+    <link rel="stylesheet" href="../assets/css/magnific-popup.css">
+    <link rel="stylesheet" href="../assets/css/style.css">
+    <link rel="stylesheet" href="../assets/css/custom-styles.css">
     <title>Servicios - Nok Services</title>
 
     <!-- Meta tags de seguridad -->
@@ -31,18 +31,18 @@
             <header id="header">
                 <nav class="navbar navbar-dark ts-separate-bg-element">
                     <!-- Removed inline styling from navbar-brand -->
-                    <a class="navbar-brand" href="index.html">
+                    <a class="navbar-brand" href="/">
                         <div class="brand-container">
                             <img src="https://flagcdn.com/w20/cl.png" alt="Bandera de Chile">
-                            <img src="assets/img/logo.png" alt="">
+                            <img src="../assets/img/logo.png" alt="">
                         </div>
                     </a>
                     <div class="navbar-nav ml-auto custom-nav">
                         <!-- Removed inline styles from nav-container -->
                         <div class="nav-container">
-                            <a href="index.html" class="nav-link">Start</a>
-                            <a href="servicios.html" class="nav-link active">Services</a>
-                            <a href="producto.html" class="nav-link">Product</a>
+                            <a href="/" class="nav-link">Start</a>
+                            <a href="/servicios/" class="nav-link active">Services</a>
+                            <a href="/producto/" class="nav-link">Product</a>
                         </div>
                     </div>
                 </nav>
@@ -158,9 +158,9 @@
 
     <!-- Background -->
     <div class="ts-background ts-shapes-canvas position-fixed ts-separate-bg-element" data-bg-color="#26005F">
-        <div class="ts-background-image ts-animate ts-scale" data-bg-image="assets/img/bg/14.png"></div>
-        <div class="ts-background-image ts-animate ts-bounce" data-bg-image="assets/img/bg/13.png"></div>
-        <div class="ts-background-image ts-animate ts-scale" data-bg-image="assets/img/bg/12.png" data-bg-opacity=".3"></div>
+        <div class="ts-background-image ts-animate ts-scale" data-bg-image="../assets/img/bg/14.png"></div>
+        <div class="ts-background-image ts-animate ts-bounce" data-bg-image="../assets/img/bg/13.png"></div>
+        <div class="ts-background-image ts-animate ts-scale" data-bg-image="../assets/img/bg/12.png" data-bg-opacity=".3"></div>
     </div>
     <!--end ts-background-->
     
@@ -176,5 +176,17 @@
         </div>
     </footer>
     <!--end footer-->
+    <!-- Scripts -->
+    <script src="../assets/js/jquery-3.3.1.min.js"></script>
+    <script src="../assets/js/popper.min.js"></script>
+    <script src="../assets/bootstrap/js/bootstrap.min.js"></script>
+    <script src="https://unpkg.com/swup@4" defer></script>
+    <script src="../assets/js/imagesloaded.pkgd.min.js"></script>
+    <script src="../assets/js/jquery.magnific-popup.min.js"></script>
+    <script src="../assets/js/jquery.countdown.min.js"></script>
+    <script src="../assets/js/jquery.validate.min.js"></script>
+    <script src="../assets/js/jquery-validate.bootstrap-tooltip.min.js"></script>
+    <script src="../assets/js/custom.js"></script>
+    <script src="../assets/js/main.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- serve `index`, `servicios`, and `producto` pages from directory-based `index.html` files
- update navigation links to `/`, `/servicios/`, and `/producto/`
- fix asset paths and ensure Swup preloading works with new routes

## Testing
- `curl -I http://localhost:8000/`
- `curl -I http://localhost:8000/servicios/`
- `curl -I http://localhost:8000/producto/`


------
https://chatgpt.com/codex/tasks/task_e_689413e56f08832a913daf7869d40ad9