### PR TITLE
Add routing configuration for clean URLs

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,11 @@
+# Enable rewrite engine
+RewriteEngine On
+
+# Map /ruta/ to /ruta/index.html
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteRule ^(.+/)$ $1index.html [L]
+
+# Fallback to index.html for SPA routes
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^ index.html [L]

--- a/404.html
+++ b/404.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting...</title>
+  <script>
+    // Redirect all unknown routes to index.html for SPA behavior
+    window.location.replace('/index.html');
+  </script>
+</head>
+<body>
+  <p>Redirecting...</p>
+</body>
+</html>

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,9 @@
+server {
+    listen 80;
+    server_name example.com;
+    root /usr/share/nginx/html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- add `404.html` redirecting unknown paths to `index.html` for GitHub Pages SPA
- include Apache `.htaccess` rules to serve directory `index.html` and fall back to main page
- provide Nginx config snippet using `try_files` for clean URLs

## Testing
- `curl -I http://localhost:8000/servicios/`
- `curl -I http://localhost:8000/producto/`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894177d74d4832a9b8d78cc8067bad1