### PR TITLE
Enable Swup link preloading

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -4,7 +4,11 @@
 const swup = new Swup({
     animateHistoryBrowsing: true,
     cache: true,
-    preload: true,
+    plugins: [
+        new SwupPreloadPlugin({
+            preloadHoveredLinks: true,
+        })
+    ]
 });
 
 // Variable para mantener la instancia del mapa y evitar reinicialización

--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
     <script type="text/javascript"
         src="https://cdn.jsdelivr.net/npm/@emailjs/browser@3/dist/email.min.js" defer></script>
     <script src="https://unpkg.com/swup@4" defer></script>
+    <script src="https://unpkg.com/@swup/preload-plugin@3" defer></script>
 
     <!-- Agregar meta tags de seguridad -->
     <meta http-equiv="Content-Security-Policy" content="default-src 'self' https:; script-src 'self' https: 'unsafe-inline' 'unsafe-eval'; style-src 'self' https: 'unsafe-inline';">

--- a/index/index.html
+++ b/index/index.html
@@ -26,6 +26,7 @@
     <script type="text/javascript"
         src="https://cdn.jsdelivr.net/npm/@emailjs/browser@3/dist/email.min.js" defer></script>
     <script src="https://unpkg.com/swup@4" defer></script>
+    <script src="https://unpkg.com/@swup/preload-plugin@3" defer></script>
 
     <!-- Agregar meta tags de seguridad -->
     <meta http-equiv="Content-Security-Policy" content="default-src 'self' https:; script-src 'self' https: 'unsafe-inline' 'unsafe-eval'; style-src 'self' https: 'unsafe-inline';">

--- a/producto/index.html
+++ b/producto/index.html
@@ -125,6 +125,7 @@
     <script src="../assets/js/popper.min.js"></script>
     <script src="../assets/bootstrap/js/bootstrap.min.js"></script>
     <script src="https://unpkg.com/swup@4" defer></script>
+    <script src="https://unpkg.com/@swup/preload-plugin@3" defer></script>
     <script src="../assets/js/imagesloaded.pkgd.min.js"></script>
     <script src="../assets/js/custom.js"></script>
     <script src="../assets/js/main.js" defer></script>

--- a/servicios/index.html
+++ b/servicios/index.html
@@ -181,6 +181,7 @@
     <script src="../assets/js/popper.min.js"></script>
     <script src="../assets/bootstrap/js/bootstrap.min.js"></script>
     <script src="https://unpkg.com/swup@4" defer></script>
+    <script src="https://unpkg.com/@swup/preload-plugin@3" defer></script>
     <script src="../assets/js/imagesloaded.pkgd.min.js"></script>
     <script src="../assets/js/jquery.magnific-popup.min.js"></script>
     <script src="../assets/js/jquery.countdown.min.js"></script>


### PR DESCRIPTION
## Summary
- add SwupPreloadPlugin to swup configuration to prefetch next pages on link hover
- load Swup preload plugin on all pages using Swup for smoother transitions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68941a42ab38832a8d6b60d150b81626