### PR TITLE
Fix history URL for Swup transitions

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -138,12 +138,24 @@ function runPageScripts() {
 // =================================================================
 // SWUP HOOKS - GESTIÓN DEL CICLO DE VIDA DE LA PÁGINA
 // =================================================================
+/**
+ * Elimina `index.html` de la URL actual para mantener rutas limpias.
+ */
+function cleanUrl() {
+    history.replaceState(null, '', location.pathname.replace(/index\.html$/, ''));
+}
 
 // Se ejecuta una vez cuando la página carga por primera vez
-document.addEventListener('DOMContentLoaded', runPageScripts);
+document.addEventListener('DOMContentLoaded', () => {
+    cleanUrl();
+    runPageScripts();
+});
 
 // Se ejecuta cada vez que Swup carga una nueva página
-swup.hooks.on('page:view', runPageScripts);
+swup.hooks.on('page:view', () => {
+    cleanUrl();
+    runPageScripts();
+});
 
 // Clases para las animaciones de Swup
 swup.hooks.on('visit:start', () => {


### PR DESCRIPTION
## Summary
- limpiar `index.html` de la URL en cada transición de Swup

## Testing
- `python3 - <<'PY' ... PY` *(fallan recursos externos con `ERR_CERT_AUTHORITY_INVALID`)*

------
https://chatgpt.com/codex/tasks/task_e_689418d1fc90832a9e51239ae4d71940