### PR TITLE
Remove Swup wrapper from test page

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -280,7 +280,7 @@
     </style>
 </head>
 <body class="has-loading-screen ts-theme-dark">
-  <div id="swup" class="transition-fade">
+  <div class="ts-page-wrapper">
   <div class="background-artistic"></div>
   <div class="container">
     <h1 class="text-center text-white my-5">NOK SOFTWARE</h1>
@@ -381,9 +381,6 @@
   </div>
   <script src="../assets/js/jquery-3.3.1.min.js"></script>
   <script src="../assets/bootstrap/js/bootstrap.min.js"></script>
-  <script src="https://unpkg.com/swup@4" defer></script>
-  <script src="https://unpkg.com/@swup/preload-plugin@3" defer></script>
   <script src="../assets/js/terminal.js" defer></script>
-  <script src="../assets/js/main.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Simplify `/test/` by removing the Swup wrapper and moving its contents into the standard `ts-page-wrapper` container.
- Drop unused Swup-related scripts so only necessary assets are loaded.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python3 -m http.server 8000 &` and `curl -I http://localhost:8000/test/`


------
https://chatgpt.com/codex/tasks/task_e_689426723af4832a9078125cd5c43a72