### PR TITLE
Preload test page for swup transitions

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -11,6 +11,9 @@ const swup = new Swup({
     ]
 });
 
+// Precargar la página de prueba para acelerar la transición
+swup.preload('/test/');
+
 // Variable para mantener la instancia del mapa y evitar reinicialización
 let mapInstance = null;
 


### PR DESCRIPTION
## Summary
- Preload `/test/` route via SwupPreloadPlugin to speed up navigation to the test page.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68942674aa8c832a907ad1ab1351345a