### PR TITLE
Enable Swup transitions on test page

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -282,7 +282,7 @@
 <body class="has-loading-screen ts-theme-dark">
   <div class="ts-page-wrapper">
   <div class="background-artistic"></div>
-  <div class="container">
+  <div id="swup" class="container transition-fade">
     <h1 class="text-center text-white my-5">NOK SOFTWARE</h1>
     
     <!-- Login Card with central logo -->
@@ -381,6 +381,9 @@
   </div>
   <script src="../assets/js/jquery-3.3.1.min.js"></script>
   <script src="../assets/bootstrap/js/bootstrap.min.js"></script>
+  <script src="https://unpkg.com/swup@4" defer></script>
+  <script src="https://unpkg.com/@swup/preload-plugin@3" defer></script>
   <script src="../assets/js/terminal.js" defer></script>
+  <script src="../assets/js/main.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Wrap main content in Swup container on test page
- Load Swup scripts and shared main.js for navigation

## Testing
- `npm test` (fails: ENOENT package.json)
- `python -m http.server 8000` & `curl http://localhost:8000/test/`

------
https://chatgpt.com/codex/tasks/task_e_68942fe48f40832ab66bab81fa1c8d00