### PR TITLE
fix: evita reemplazar historial si no hay index.html

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -145,7 +145,9 @@ function runPageScripts() {
  * Elimina `index.html` de la URL actual para mantener rutas limpias.
  */
 function cleanUrl() {
-    history.replaceState(null, '', location.pathname.replace(/index\.html$/, ''));
+    if (location.pathname.endsWith('index.html')) {
+        history.replaceState(null, '', location.pathname.replace(/index\.html$/, ''));
+    }
 }
 
 // Se ejecuta una vez cuando la página carga por primera vez


### PR DESCRIPTION
## Summary
- only rewrite URL when pathname ends with `index.html`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node test-history.js`

------
https://chatgpt.com/codex/tasks/task_e_689566cca514832a8feeda1889cd8f3b