### PR TITLE
Remove Swup test preload to avoid phantom history routes

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -12,7 +12,7 @@ const swup = new Swup({
 });
 
 // Precargar la página de prueba para acelerar la transición
-swup.preload('/test/');
+// swup.preload('/test/');
 
 // Variable para mantener la instancia del mapa y evitar reinicialización
 let mapInstance = null;


### PR DESCRIPTION
## Summary
- Comment out Swup test preload to prevent phantom history entry

## Testing
- `NODE_PATH=$(npm root -g) node - <<'NODE'
const puppeteer = require('puppeteer');
(async () => {
  const browser = await puppeteer.launch({headless: 'new', args: ['--no-sandbox', '--disable-setuid-sandbox']});
  const page = await browser.newPage();
  await page.goto('http://localhost:8000/', {waitUntil: 'networkidle0'});
  const initialLength = await page.evaluate(() => history.length);
  await page.waitForSelector('a[href="/servicios/"]');
  await page.click('a[href="/servicios/"]');
  await page.waitForFunction(() => document.querySelector('h1')?.textContent.trim() === 'Our Services');
  const afterNavLength = await page.evaluate(() => history.length);
  await page.goBack();
  await page.waitForFunction(() => document.querySelector('h1')?.textContent.trim() === 'Technological Developments');
  const finalLength = await page.evaluate(() => history.length);
  const currentUrl = page.url();
  console.log('initialLength', initialLength);
  console.log('afterNavLength', afterNavLength);
  console.log('finalLength', finalLength);
  console.log('currentUrl', currentUrl);
  await browser.close();
})();
NODE`

------
https://chatgpt.com/codex/tasks/task_e_689568c952a4832ab74ca2075303dcda