### PR TITLE
Avoid duplicate Swup initialization

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,18 +1,44 @@
 // =================================================================
 // SWUP - GESTOR DE TRANSICIONES DE PÁGINA
 // =================================================================
-const swup = new Swup({
-    animateHistoryBrowsing: true,
-    cache: true,
-    plugins: [
-        new SwupPreloadPlugin({
-            preloadHoveredLinks: true,
-        })
-    ]
-});
+let swup = window.swup;
 
-// Precargar la página de prueba para acelerar la transición
-// swup.preload('/test/');
+if (!swup) {
+    swup = new Swup({
+        animateHistoryBrowsing: true,
+        cache: true,
+        plugins: [
+            new SwupPreloadPlugin({
+                preloadHoveredLinks: true,
+            })
+        ]
+    });
+    window.swup = swup;
+
+    // Precargar la página de prueba para acelerar la transición
+    // swup.preload('/test/');
+
+    // Se ejecuta una vez cuando la página carga por primera vez
+    document.addEventListener('DOMContentLoaded', () => {
+        cleanUrl();
+        runPageScripts();
+    });
+
+    // Se ejecuta cada vez que Swup carga una nueva página
+    swup.hooks.on('page:view', () => {
+        cleanUrl();
+        runPageScripts();
+    });
+
+    // Clases para las animaciones de Swup
+    swup.hooks.on('visit:start', () => {
+        document.body.classList.add('is-changing');
+    });
+
+    swup.hooks.on('visit:end', () => {
+        document.body.classList.remove('is-changing');
+    });
+}
 
 // Variable para mantener la instancia del mapa y evitar reinicialización
 let mapInstance = null;
@@ -150,23 +176,3 @@ function cleanUrl() {
     }
 }
 
-// Se ejecuta una vez cuando la página carga por primera vez
-document.addEventListener('DOMContentLoaded', () => {
-    cleanUrl();
-    runPageScripts();
-});
-
-// Se ejecuta cada vez que Swup carga una nueva página
-swup.hooks.on('page:view', () => {
-    cleanUrl();
-    runPageScripts();
-});
-
-// Clases para las animaciones de Swup
-swup.hooks.on('visit:start', () => {
-    document.body.classList.add('is-changing');
-});
-
-swup.hooks.on('visit:end', () => {
-    document.body.classList.remove('is-changing');
-});

--- a/producto/index.html
+++ b/producto/index.html
@@ -125,8 +125,6 @@
     <script src="../assets/js/jquery-3.3.1.min.js"></script>
     <script src="../assets/js/popper.min.js"></script>
     <script src="../assets/bootstrap/js/bootstrap.min.js"></script>
-    <script src="https://unpkg.com/swup@4" defer></script>
-    <script src="https://unpkg.com/@swup/preload-plugin@3" defer></script>
     <script src="../assets/js/imagesloaded.pkgd.min.js"></script>
     <script src="../assets/js/custom.js"></script>
     <script src="../assets/js/main.js" defer></script>

--- a/servicios/index.html
+++ b/servicios/index.html
@@ -182,8 +182,6 @@
     <script src="../assets/js/jquery-3.3.1.min.js"></script>
     <script src="../assets/js/popper.min.js"></script>
     <script src="../assets/bootstrap/js/bootstrap.min.js"></script>
-    <script src="https://unpkg.com/swup@4" defer></script>
-    <script src="https://unpkg.com/@swup/preload-plugin@3" defer></script>
     <script src="../assets/js/imagesloaded.pkgd.min.js"></script>
     <script src="../assets/js/jquery.magnific-popup.min.js"></script>
     <script src="../assets/js/jquery.countdown.min.js"></script>


### PR DESCRIPTION
## Summary
- Remove Swup library references from product and services pages to rely on global include
- Guard Swup setup in `main.js` so it only runs once per visit

## Testing
- `python /tmp/test_nav.py` *(failed: BrowserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68956b6b8f08832aa6ef84d4362755ec