### PR TITLE
Add footer to 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -10,5 +10,16 @@
 </head>
 <body>
   <p>Redirecting...</p>
+  <footer id="footer">
+    <div class="clearfix py-4">
+      <div class="text-center">
+        <small style="display: inline-flex; align-items: center; gap: 10px; justify-content: center;">
+          <img src="https://flagcdn.com/w20/cl.png" alt="Bandera de Chile" style="width: 20px; height: auto;" />
+          <img src="assets/img/logo.png" alt="Logo NokServices" style="width: 20px; height: auto;" />
+          <span>© <span id="current-year">2025</span> NokServices Technology, All Rights Reserved.</span>
+        </small>
+      </div>
+    </div>
+  </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add standard footer with logos and copyright to 404.html

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68957120ae6c832aaff429cd8906ea5b