### PR TITLE
Remove duplicate footer from services page

### DIFF
--- a/servicios/index.html
+++ b/servicios/index.html
@@ -165,19 +165,6 @@
     </div>
     <!--end ts-background-->
     
-    <!-- Added footer at end of page -->
-    <footer id="footer">
-        <div class="clearfix py-4">
-            <div class="text-center">
-                <small style="display: inline-flex; align-items: center; gap: 10px; justify-content: center;">
-                    <img src="https://flagcdn.com/w20/cl.png" alt="Bandera de Chile" style="width: 20px; height: auto;">
-                    <img src="../assets/img/logo.png" alt="Logo NokServices" style="width: 20px; height: auto;">
-                    <span>© 2025 NokServices Tecnology, All Rights Reserved.</span>
-                </small>
-            </div>
-        </div>
-    </footer>
-    <!--end footer-->
     <!-- Scripts -->
     <script src="../assets/js/jquery-3.3.1.min.js"></script>
     <script src="../assets/js/popper.min.js"></script>


### PR DESCRIPTION
## Summary
- remove duplicated footer from servicios/index.html, leaving a single footer with the flag and corporate logo

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68957090a594832aa7a3455af53b5901